### PR TITLE
Add support for generator parametrization via options

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,21 +29,21 @@ grunt.initConfig({
 Type: 'String' or 'function'
 Default:
 ```
-{
-    '.ejs': jsxgettext.generateFromEJS,
-    '.hbs': jsxgettext.generateFromHandlebars,
-    '.jade': jsxgettext.generateFromJade,
-    '.swig': jsxgettext.generateFromSwig
-}
+[
+    {ext: '.ejs': generator: jsxgettext.generateFromEJS},
+    {ext: '.hbs', generator: jsxgettext.generateFromHandlebars},
+    {ext: '.jade', generator: jsxgettext.generateFromJade},
+    {ext: '.swig', generator: jsxgettext.generateFromSwig} 
+]
 ```
 Used to add/modify mapping between file extensions and generators (parsers) used by jsxgettext.
 
 This can be one of the following:
 
 - Specifying a pair of extensions. Used to add a extensions for existing generators. For example 
-if we wanted to tell jsxgettext that our handlebars templates have '.html' extensions: ```{'.html': '.hbs'}```
-- Specifying an extension along with the jsxgettext generator function name: ```{'.html': 'generateFromSwig'}```
-- Specifying an extension along with an generator function: ```{'.html': jsxgettext.generateFromSwig}```
+if we wanted to tell jsxgettext that our handlebars templates have '.html' extensions: ```{ext: '.html': generator: '.hbs'}```
+- Specifying an extension along with the jsxgettext generator function name: ```{ext: '.html': generator: 'generateFromSwig'}```
+- Specifying an extension along with an generator function: ```{ext: '.html': generator: jsxgettext.generateFromSwig}```
 
 
 ### Getting Started

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ grunt.initConfig({
 			files: [
 				{
 					src: ['tests/fixtures/**/*.*js', '!ignored'],
-					dest: './test.pot'
+					output: 'test.po',
+					'output-dir': './translations/'
 				}
 			],
 			options: {

--- a/README.md
+++ b/README.md
@@ -22,6 +22,30 @@ grunt.initConfig({
 })
 ```
 
+### Options
+
+**** generators
+
+Type: 'String' or 'function'
+Default:
+```
+{
+    '.ejs': jsxgettext.generateFromEJS,
+    '.hbs': jsxgettext.generateFromHandlebars,
+    '.jade': jsxgettext.generateFromJade,
+    '.swig': jsxgettext.generateFromSwig
+}
+```
+Used to add/modify mapping between file extensions and generators (parsers) used by jsxgettext.
+
+This can be one of the following:
+
+- Specifying a pair of extensions. Used to add a extensions for existing generators. For example 
+if we wanted to tell jsxgettext that our handlebars templates have '.html' extensions: ```{'.html': '.hbs'}```
+- Specifying an extension along with the jsxgettext generator function name: ```{'.html': 'generateFromSwig'}```
+- Specifying an extension along with an generator function: ```{'.html': jsxgettext.generateFromSwig}```
+
+
 ### Getting Started
 This plugin requires Grunt `~0.4.2`
 ```shell

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,10 +6,10 @@ var jsxgettext = require('jsxgettext');
 var fs = require('fs');
 
 /*
-options: {
-	files: ['file-path','file-path'],
-	+ jsxgettext options
-}
+ options: {
+ files: ['file-path','file-path'],
+ + jsxgettext options
+ }
  */
 module.exports = function (grunt, options, cb) {
 	var generators = {
@@ -17,12 +17,12 @@ module.exports = function (grunt, options, cb) {
 		'.hbs': jsxgettext.generateFromHandlebars
 	};
 
-    // dynamically update generators mapping
-    if (options.generators) {
-        _.forEach(options.generators, function(elem) {
-            generators[elem.ext] = generators[elem.generator];
-        });
-    }
+	// dynamically update generators mapping
+	if (options.generators) {
+		_.forEach(options.generators, function(elem) {
+			generators[elem.ext] = generators[elem.generator];
+		});
+	}
 
 	var files = {};
 	var dest = options.dest;

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,13 +14,26 @@ var fs = require('fs');
 module.exports = function (grunt, options, cb) {
 	var generators = {
 		'.ejs': jsxgettext.generateFromEJS,
-		'.hbs': jsxgettext.generateFromHandlebars
+		'.hbs': jsxgettext.generateFromHandlebars,
+		'.jade': jsxgettext.generateFromJade,
+		'.swig': jsxgettext.generateFromSwig
 	};
 
 	// dynamically update generators mapping
 	if (options.generators) {
 		_.forEach(options.generators, function(elem) {
-			generators[elem.ext] = generators[elem.generator];
+			// elem.generator can be either a string or a generator method (i.e. own generator or import from jsxgettext)
+			if (typeof elem.generator === 'string' || elem.generator instanceof String) {
+				// elem.generator can be an extension, which is used to remap predefined generators to different extensions
+				// or elem.generator is the name of an generator method implemented in jsxgettext
+				if (elem.generator.match(/^\..*/)) {
+					generators[elem.ext] = generators[elem.generator];
+				} else {
+					generators[elem.ext] = jsxgettext[elem.generator];
+				}
+			} else {
+				generators[elem.ext] = elem.generator;
+			}
 		});
 	}
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,14 @@ module.exports = function (grunt, options, cb) {
 		'.ejs': jsxgettext.generateFromEJS,
 		'.hbs': jsxgettext.generateFromHandlebars
 	};
+
+    // dynamically update generators mapping
+    if (options.generators) {
+        _.forEach(options.generators, function(elem) {
+            generators[elem.ext] = generators[elem.generator];
+        });
+    }
+
 	var files = {};
 	var dest = options.dest;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,6 +21,10 @@ module.exports = function (grunt, options, cb) {
 
 	// dynamically update generators mapping
 	if (options.generators) {
+		if (!_.isArray(options.generators)) {
+			options.generators = [options.generators];
+		}
+
 		_.forEach(options.generators, function(elem) {
 			// elem.generator can be either a string or a generator method (i.e. own generator or import from jsxgettext)
 			if (typeof elem.generator === 'string' || elem.generator instanceof String) {

--- a/tasks/grunt-jsxgettext.js
+++ b/tasks/grunt-jsxgettext.js
@@ -10,7 +10,13 @@ module.exports = function (grunt) {
 		var done = self.async();
 
 		async.each(self.files, function(fileSet, eCb) {
-            var dest = path.join(fileSet['output-dir'] || '', fileSet.output);
+			var dest;
+			if (typeof fileSet.dest !== 'undefined' && fileSet.dest) {
+				dest = fileSet.dest;
+			} else {
+				dest = path.join(fileSet['output-dir'] || '', fileSet.output);
+			}
+
 			var options = _.defaults(self.options(), {
 				files: fileSet.src,
                 dest: dest,

--- a/tasks/grunt-jsxgettext.js
+++ b/tasks/grunt-jsxgettext.js
@@ -1,5 +1,6 @@
 'use strict';
 var _ = require('lodash');
+var path = require('path');
 var task = require('../lib');
 var async = require('async');
 
@@ -9,13 +10,15 @@ module.exports = function (grunt) {
 		var done = self.async();
 
 		async.each(self.files, function(fileSet, eCb) {
+            var dest = path.join(fileSet['output-dir'] || '', fileSet.output);
 			var options = _.defaults(self.options(), {
-				files: fileSet.src
+				files: fileSet.src,
+                dest: dest
 			});
 			task(grunt, options, function (err, res) {
 				if(err) return eCb(err);
 
-				grunt.file.write(fileSet.dest, res);
+				grunt.file.write(dest, res);
 				eCb();
 			});
 		}, function(err) {

--- a/tasks/grunt-jsxgettext.js
+++ b/tasks/grunt-jsxgettext.js
@@ -13,7 +13,9 @@ module.exports = function (grunt) {
             var dest = path.join(fileSet['output-dir'] || '', fileSet.output);
 			var options = _.defaults(self.options(), {
 				files: fileSet.src,
-                dest: dest
+                dest: dest,
+                'output-dir': fileSet['output-dir'],
+                output: fileSet['output']
 			});
 			task(grunt, options, function (err, res) {
 				if(err) return eCb(err);

--- a/tests/fixtures/files/test.html
+++ b/tests/fixtures/files/test.html
@@ -1,0 +1,4 @@
+<div class="container login panel">
+	<span class="control-label" for="username"><%= dgettext("Text 0") %></span>
+	<span class="control-label" for="username"><%= dngettext("Text 1: %d items", 2) %></span>
+</div>

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -3,6 +3,7 @@ var grunt = require("grunt");
 var path = require("path");
 var task = require("../lib");
 var util = require('util');
+var jsxgettext = require('jsxgettext');
 
 test("N files work", function (t) {
 	var options = {
@@ -32,6 +33,66 @@ test("Ignores non existent files", function (t) {
 	task(grunt, options, function (err, res) {
 		t.ok(err, "An error should be returned, received: " + util.inspect(err, {depth: null}));
 		t.notOk(res, "No results should have been returned, received: " + util.inspect(res, {depth: null}));
+		t.end();
+	});
+});
+
+test("Generator extension mapping works", function(t) {
+	var options = {
+		files: [
+			path.join(__dirname, "fixtures/files/test.html"),
+			path.join(__dirname, "fixtures/files/test.js")
+		],
+		keyword: 'dgettext|dngettext',
+		generators: {
+			ext: ".html",
+			generator: ".ejs"
+		}
+	};
+
+	task(grunt, options, function (err, res) {
+		t.notOk(err, "No error should be returned, received: " + util.inspect(err, {depth: null}));
+		t.ok(res, "A results should have been returned, received: " + util.inspect(res, {depth: null}));
+		t.end();
+	});
+});
+
+test("Generator generator name mapping works", function(t) {
+	var options = {
+		files: [
+			path.join(__dirname, "fixtures/files/test.html"),
+			path.join(__dirname, "fixtures/files/test.js")
+		],
+		keyword: 'dgettext|dngettext',
+		generators: {
+			ext: ".html",
+			generator: "generateFromEJS"
+		}
+	};
+
+	task(grunt, options, function (err, res) {
+		t.notOk(err, "No error should be returned, received: " + util.inspect(err, {depth: null}));
+		t.ok(res, "A results should have been returned, received: " + util.inspect(res, {depth: null}));
+		t.end();
+	});
+});
+
+test("Generator generator function mapping works", function(t) {
+	var options = {
+		files: [
+			path.join(__dirname, "fixtures/files/test.html"),
+			path.join(__dirname, "fixtures/files/test.js")
+		],
+		keyword: 'dgettext|dngettext',
+		generators: {
+			ext: ".html",
+			generator: jsxgettext.generateFromEJS
+		}
+	};
+
+	task(grunt, options, function (err, res) {
+		t.notOk(err, "No error should be returned, received: " + util.inspect(err, {depth: null}));
+		t.ok(res, "A results should have been returned, received: " + util.inspect(res, {depth: null}));
 		t.end();
 	});
 });


### PR DESCRIPTION
Added Jade and Swig to the list of default generators.

Added parametrization of generators via options, because often people use non-default extensions for their templates. And sometimes they might want to overload or supply their own generators from outside.